### PR TITLE
Cleanup unnecessary readme comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,6 @@ Other things to remember that the `.osx` script doesn't handle for you:
 
 * Terminal > Preferences > Profiles > Keyboard > Use Option as Meta key
 * Keychain Access > Preferences > Show keychain status in menu bar
-* System Preferences > Trackpad > Check every single box in every section
 * Open DropBox and sign in > Choose folders to sync > Start unchecking everything except:
   * 1Password
   * Temp

--- a/README.md
+++ b/README.md
@@ -49,7 +49,6 @@ Other things to remember that the `.osx` script doesn't handle for you:
 * Terminal > Preferences > Profiles > Keyboard > Use Option as Meta key
 * Keychain Access > Preferences > Show keychain status in menu bar
 * System Preferences > Trackpad > Check every single box in every section
-* If a desktop or server Mac: System Preferences > Energy Saver > Computer sleep > Never
 * Open DropBox and sign in > Choose folders to sync > Start unchecking everything except:
   * 1Password
   * Temp


### PR DESCRIPTION
Remove comments about the trackpad and sleep settings, since they're changed by `.osx`.